### PR TITLE
set tablename to Localizations and grab metadata if present during upload

### DIFF
--- a/pyme_omero/recipe_modules/omero_upload.py
+++ b/pyme_omero/recipe_modules/omero_upload.py
@@ -86,7 +86,12 @@ class ImageUpload(OutputModule):
                     # default to hdf unless h5r is manually specified
                     loc_filename = loc_filename + '.hdf'
                 loc_filenames.append(loc_filename)
-                namespace[loc_key].to_hdf(loc_filename)
+                try:
+                    mdh = namespace[loc_key].mdh
+                except AttributeError:
+                    mdh = None
+                namespace[loc_key].to_hdf(loc_filename, 'Localizations',
+                                          metadata=mdh)
             
             upload_image_from_file(out_filename, self.omero_dataset, 
                                    self.omero_project, loc_filenames)

--- a/pyme_omero/visgui_modules/omero_loader.py
+++ b/pyme_omero/visgui_modules/omero_loader.py
@@ -105,12 +105,23 @@ class OMEROLoader(object):
             dataset = str(dlg.dataset.GetValue())
 
             current = os.path.join(self._tempdir.name, self.pipeline.selectedDataSourceKey + '.hdf')
-            self.pipeline.selectedDataSource.to_hdf(current)
+            try:
+                mdh = self.pipeline.selectedDataSource.mdh
+            except AttributeError:
+                mdh = self.pipeline.mdh
+            self.pipeline.selectedDataSource.to_hdf(current, 'Localizations', 
+                                                    metadata=mdh)
             attachments = [current]
 
-            if 'Localizations' in self.pipeline.dataSources.keys():
+            if 'Localizations' in self.pipeline.dataSources.keys() and self.pipeline.selectedDataSourceKey !='Localizations':
                 locs = os.path.join(self._tempdir.name, 'Localizations.hdf')
-                self.pipeline.dataSources['Localizations'].to_hdf(locs)
+                try:
+                    mdh = self.pipeline.dataSources['Localizations'].mdh
+                except AttributeError:
+                    mdh = self.pipeline.mdh
+                self.pipeline.dataSources['Localizations'].to_hdf(locs, 
+                                                                  'Localizations',
+                                                                  metadata=mdh)
                 attachments.append(locs)
             
             upload_image_from_file(snapshot, dataset, project, attachments)


### PR DESCRIPTION
Note this does not address PYME acquisition events just yet. Will need to look at results of https://github.com/python-microscopy/python-microscopy/pull/284 or alternative to know where to grab them. 