### PR TITLE
upload upstream h5r file in its entirety when available

### DIFF
--- a/pyme_omero/core.py
+++ b/pyme_omero/core.py
@@ -129,14 +129,37 @@ def upload_image_from_file(file, dataset_name, project_name='',
                 # have to have loadedness -> True to link an annotation
                 image = conn.getObject("Image", image_id)
                 for attachment in attachments:
-                    # TODO - add guess_mimetype here
-                    namespace='pyme.localizations'
-                    mimetype='application/octet-stream'
-                    file_ann = conn.createFileAnnfromLocalFile(attachment, 
-                                                        mimetype=mimetype, 
-                                                        ns=namespace, desc=None)
-                    logger.debug('Attaching FileAnnotation %d to %d' % (file_ann.getId(), image_id))
-                    image.linkAnnotation(file_ann)
+                    # TODO - add guess_mimetype / namespace here
+                    upload_file_annotation(conn, image, attachment, 
+                                           namespace='pyme.localizations')
+
+def upload_file_annotation(connection, image, file, 
+                           mimetype='application/octet-stream', 
+                           namespace='', description=None):
+    """ upload a file as an attachment to an already-uploaded image
+
+    Parameters
+    ----------
+    connection : omero.gateway.BlitzGateway
+        an open connection to an OMERO server
+    image : int or omero object wrapped
+        either an image_id or a Blitz object wrapper instance of the image
+    file : str
+        path to the file on disk
+    mimetype : str, optional
+        by default 'application/octet-stream'
+    namespace : str, optional
+        by default ''
+    description : str, optional
+        by default None
+    """
+    if isinstance(image, str):
+        image = connection.getObject("Image", image)
+    file_ann = connection.createFileAnnfromLocalFile(file, mimetype=mimetype,
+                                                     ns=namespace, desc=None)
+    logger.debug('Attaching FileAnnotation %d to %d' % (file_ann.getId(), 
+                                                        image.getId()))
+    image.linkAnnotation(file_ann)
 
 def localization_files_from_image_url(image_url, out_dir):
     """

--- a/pyme_omero/recipe_modules/omero_upload.py
+++ b/pyme_omero/recipe_modules/omero_upload.py
@@ -64,11 +64,11 @@ class ImageUpload(OutputModule):
             The recipe namespace
         context : dict
             Information about the source file to allow pattern substitution to 
-            generate the output name. At least 'filestub' (which is the filename
-            without any extension) should be resolved.
+            generate the output name. At least 'file_stub' (which is the 
+            filename without any extension) should be resolved.
 
         """
-        from pyme_omero.core import upload_image_from_file
+        from pyme_omero import core
         from tempfile import TemporaryDirectory
         
         out_filename = self.filePattern.format(**context)
@@ -90,11 +90,23 @@ class ImageUpload(OutputModule):
                     mdh = namespace[loc_key].mdh
                 except AttributeError:
                     mdh = None
-                namespace[loc_key].to_hdf(loc_filename, 'Localizations',
-                                          metadata=mdh)
+                namespace[loc_key].to_hdf(loc_filename, loc_key, metadata=mdh)
             
-            upload_image_from_file(out_filename, self.omero_dataset, 
-                                   self.omero_project, loc_filenames)
+            
+            image_id = core.upload_image_from_file(out_filename, 
+                                                   self.omero_dataset, 
+                                                   self.omero_project, 
+                                                   loc_filenames)
+        
+        # if an h5r file is the principle input, upload it
+        try:
+            principle = os.path.join(context['input_dir'], 
+                                     context['file_stub']) + '.h5r'
+            with core.local_or_named_temp_filename(principle) as f:
+                core.connect_and_upload_file_annotation(image_id, f,
+                                                        namespace='pyme.localizations')
+        except (KeyError, IOError):
+            pass
     
     @property
     def inputs(self):


### PR DESCRIPTION
solution to issue #3 for h5r files. Uploading to OMERO from PYMEVis menu items will now include the full upstream h5r file with original file stub (if there is an upstream h5r file, and if the recipe context is set to include what PYME docs say it should, which isn't always the case. see https://github.com/python-microscopy/python-microscopy/issues/566).